### PR TITLE
Prevent caching of response

### DIFF
--- a/EventListener/MaintenanceListener.php
+++ b/EventListener/MaintenanceListener.php
@@ -46,12 +46,16 @@ final readonly class MaintenanceListener implements EventSubscriberInterface
         }
 
         if ($request->cookies->get('maintenance_bypass') === $this->bypassToken) {
+            $response = $event->getResponse() ?? new Response();
+            $response->headers->set('Vary', 'Cookie');
             return;
         }
 
         $content = $this->twig->render($this->templatePath);
 
         $response = new Response($content, 503);
+        $response->headers->set('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0');
+        $response->headers->set('Pragma', 'no-cache');
         $event->setResponse($response);
     }
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 ## Install
 
+This Symfony bundle shows a maintenance page if mode is enabled via environment variable.
+The maintenance page can be bypassed via a configurable cookie or a configurable allowed IP address. This ensures, that the maintenance mode is only visible for the audience.
+
 **Install this bundle via Composer:**
 
 `composer require php-translation/symfony-bundle`
@@ -13,6 +16,7 @@ Then, configure the bundle. An example configuration looks like this:
 maintenance:
   enabled: '%env(bool:MAINTENANCE_ENABLED)%'
   bypass_token: 'bypass'
+  ip_addresses: ["127.0.0.1"]
 ```
 
 **Add bundle to your bundles.php**


### PR DESCRIPTION
**Problem:**
When cookie is set to bypass the maintenance it is also bypassed for other users, at least on hosting provider like Heroku.

**Solution:**
Avoid caching of response.